### PR TITLE
[gpd-setup] fix regex

### DIFF
--- a/archlive/airootfs/usr/bin/gpd-setup
+++ b/archlive/airootfs/usr/bin/gpd-setup
@@ -46,7 +46,7 @@ blacklist_pcspkr() {
 
 set_consolefont() {
         echo "FONT=latarcyrheb-sun32" > ${volume}/etc/vconsole.conf && \
-        sed -i 's/HOOKS=.*"/HOOKS=\"consolefont base udev autodetect keyboard keymap modconf block encrypt lvm2 filesystems fsck\"/g' ${volume}/etc/mkinitcpio.conf && \
+        sed -i '/^HOOKS=/c\HOOKS=(consolefont base udev autodetect keyboard keymap modconf block encrypt lvm2 filesystems fsck)' ${volume}/etc/mkinitcpio.conf && \
         echo "Successfully set the consolefont." || \
         echo "Unable to set the consolefont, please see archwiki page on GPD Pocket."
 }


### PR DESCRIPTION
As mention in Issue #4 there is an problem with adding the needed parameters for *encrypt* and *lvm2*  after you pointed me to the code I check the sed command and found out it's not working as expected.

This PR will change the `sed` and is adding the needed parameters.  